### PR TITLE
去除无用的log

### DIFF
--- a/middleware/spider-server.js
+++ b/middleware/spider-server.js
@@ -319,7 +319,7 @@ class SpiderServer {
       try {
         data.data = JSON.parse(data.data)
       } catch (e) {
-        console.log(e)
+        // ignore
       }
       // 自动更新cookieJar
       requestObj.ctx.cookieJar = tough.CookieJar.fromJSON(data.cookie)


### PR DESCRIPTION
spider-server中转换json的错误是正常的，不应该被log出来，不然控制台就炸了